### PR TITLE
Removed the extra paren. in the example code.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ Example
 .. code:: python
 
     (ggplot(mtcars, aes('wt', 'mpg', color='factor(gear)'))
-     + geom_point())
+     + geom_point()
      + stat_smooth(method='lm')
      + facet_wrap('~gear'))
 


### PR DESCRIPTION
The example code fails with a syntax error. It contains a erroneous extra parenthesis.